### PR TITLE
hotfix: improve segment check for default host

### DIFF
--- a/scripts/analytics/config.js
+++ b/scripts/analytics/config.js
@@ -1,5 +1,5 @@
 import { configFile } from "../utils/configFile.js";
-import { HOST_CONFIG_NAME } from "../utils/constants.js";
+import { HOST_CONFIG_NAME, DEFAULT_HOST } from "../utils/constants.js";
 import {
   DEVELOPMENT_SEGMENT_KEY,
   PRODUCTION_SEGMENT_KEY
@@ -9,6 +9,6 @@ export const HAS_ASKED_OPT_IN_NAME = "has-asked-opt-in";
 export const OPT_IN_NAME = "opt-in";
 
 export const SEGMENT_API_KEY =
-  configFile.get(HOST_CONFIG_NAME) === "https://app.crowdbotics.com/"
+  configFile.get(HOST_CONFIG_NAME) === DEFAULT_HOST
     ? PRODUCTION_SEGMENT_KEY
     : DEVELOPMENT_SEGMENT_KEY;


### PR DESCRIPTION
## Ticket

PLAT-XXXX
_Related tickets:_
_Related PRs:_

## Type of PR

- [ ] Bugfix
- [ ] New feature
- [ ] Minor changes

## Changes introduced
Amplitude events are never being sent to production because the comparison between the host value (compared to the default host) was off one character (/)

## Test and review
Set host to production URL
Notice SEGMENT_API_KEY being the production key, not staging
