### PR TITLE
PLAT-14519: Resolving issue with segment library hanging CLI

### DIFF
--- a/scripts/analytics/wrapper.js
+++ b/scripts/analytics/wrapper.js
@@ -36,7 +36,12 @@ class AnalyticsWrapper {
 
     try {
       this.analytics = new Analytics({
-        writeKey: token
+        writeKey: token,
+        // Segment node library was built for long running node processes like express.
+        // Maintain a lower values for flush than library defaults, so that segment does not
+        // hang CLI node process while waiting for queue to flush.
+        flushAt: 3,
+        flushInterval: 100
       });
     } catch {
       // Ignore errors during initialization - TODO: log to sentry


### PR DESCRIPTION
## Ticket

PLAT-14519
_Related tickets:_
_Related PRs:_

## Type of PR

- [X] Bugfix
- [ ] New feature
- [ ] Minor changes

## Changes introduced

Segment config has two properties, flushAt and flushDuration
```
  /**
   * The number of events to enqueue before flushing. Default: 15.
   */
  flushAt?: number

  /**
   * The number of milliseconds to wait before flushing the queue automatically. Default: 10000
   */
  flushInterval?: number
```

By Default, flushAt is 15, and flushInterval is 10s. If we change `flushInterval` to 100ms  it works normal speed

