### PR TITLE
PLAT-14510 cli verbose mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,11 +41,18 @@ import {
   EnvironmentDependency
 } from "./scripts/utils/environment.js";
 import { analytics } from "./scripts/analytics/wrapper.js";
-import { HAS_ASKED_OPT_IN_NAME, OPT_IN_NAME } from "./scripts/analytics/config.js";
+import {
+  HAS_ASKED_OPT_IN_NAME,
+  OPT_IN_NAME
+} from "./scripts/analytics/config.js";
 import { EVENT } from "./scripts/analytics/constants.js";
 import { configureInitialLogin } from "./scripts/analytics/scripts.js";
 import { sentryMonitoring } from "./scripts/utils/sentry.js";
 import { setModuleDetails } from "./scripts/setModuleDetails.js";
+
+const GLOBAL_ARGS = {
+  "--verbose": Boolean
+};
 
 const gitRoot = () => {
   try {
@@ -105,6 +112,7 @@ const commands = {
   },
   parse: () => {
     const args = arg({
+      ...GLOBAL_ARGS,
       "--source": String,
       "--write": String
     });
@@ -132,6 +140,7 @@ const commands = {
     ]);
 
     const args = arg({
+      ...GLOBAL_ARGS,
       "--source": String,
       "--project": String
     });
@@ -145,6 +154,7 @@ const commands = {
     validateEnvironmentDependencies([EnvironmentDependency.Yarn]);
 
     const args = arg({
+      ...GLOBAL_ARGS,
       "--source": String,
       "--project": String
     });
@@ -158,6 +168,7 @@ const commands = {
     validateEnvironmentDependencies([EnvironmentDependency.Python]);
 
     const args = arg({
+      ...GLOBAL_ARGS,
       "--name": String,
       "--type": String,
       "--target": String,
@@ -181,6 +192,7 @@ const commands = {
   },
   commit: () => {
     const args = arg({
+      ...GLOBAL_ARGS,
       "--source": String
     });
     const modules = args._.slice(1);
@@ -193,6 +205,7 @@ const commands = {
     validateEnvironmentDependencies([EnvironmentDependency.Git]);
 
     const args = arg({
+      ...GLOBAL_ARGS,
       "--name": String
     });
     if (!args["--name"]) {
@@ -230,6 +243,7 @@ demo`;
   },
   upgrade: () => {
     const args = arg({
+      ...GLOBAL_ARGS,
       "--version": String
     });
     analytics.sendEvent({ name: EVENT.UPGRADE });
@@ -245,7 +259,9 @@ demo`;
     info();
   },
   config: () => {
-    const args = arg({});
+    const args = arg({
+      ...GLOBAL_ARGS
+    });
 
     const action = args._[1];
     const key = args._[2];
@@ -283,7 +299,7 @@ demo`;
 
   modules: async () => {
     const args = arg({
-      "--verbose": Boolean,
+      ...GLOBAL_ARGS,
       "--search": String,
       "--visibility": String,
       "--status": String,
@@ -383,7 +399,9 @@ demo`;
   },
 
   feedback: () => {
-    const args = arg({});
+    const args = arg({
+      ...GLOBAL_ARGS
+    });
     const action = args._[1];
 
     if (!action) {

--- a/index.js
+++ b/index.js
@@ -283,6 +283,7 @@ demo`;
 
   modules: async () => {
     const args = arg({
+      "--verbose": Boolean,
       "--search": String,
       "--visibility": String,
       "--status": String,

--- a/scripts/utils/apiClient.js
+++ b/scripts/utils/apiClient.js
@@ -46,7 +46,7 @@ class ApiClient {
       url += "?" + new URLSearchParams(params).toString();
     }
 
-    logger.log("API Request", method, url);
+    logger.verbose("API Request", method, url);
 
     const response = await fetch(url, {
       body: body ? JSON.stringify(body) : undefined,
@@ -58,7 +58,7 @@ class ApiClient {
       method: method
     });
 
-    logger.log(
+    logger.verbose(
       "API Response",
       method,
       url,

--- a/scripts/utils/apiClient.js
+++ b/scripts/utils/apiClient.js
@@ -7,6 +7,7 @@ import {
 import fetch from "node-fetch";
 import { formatUrlPath } from "./url.js";
 import { invalid } from "../../utils.js";
+import { logger } from "./logger.js";
 
 class ApiClient {
   get(options) {
@@ -45,6 +46,8 @@ class ApiClient {
       url += "?" + new URLSearchParams(params).toString();
     }
 
+    logger.log("API Request", method, url);
+
     const response = await fetch(url, {
       body: body ? JSON.stringify(body) : undefined,
       headers: {
@@ -54,6 +57,14 @@ class ApiClient {
       },
       method: method
     });
+
+    logger.log(
+      "API Response",
+      method,
+      url,
+      response.status,
+      response.statusText
+    );
 
     if (shouldFailOnUnauthorized && response.status === 401) {
       // Flush newline before printing error in case console is in loading state.

--- a/scripts/utils/environment.js
+++ b/scripts/utils/environment.js
@@ -1,6 +1,7 @@
 import { execSync, spawnSync } from "node:child_process";
 import { invalid, section, valid } from "../../utils.js";
 import { configFile } from "./configFile.js";
+import { logger } from "./logger.js";
 
 const ENVIRONMENT_VERSIONS_CONFIG_NAME = "environment-versions";
 const PYTHON_VERSION_REGEX = /Python (3\.[0-9]*)/;
@@ -39,6 +40,8 @@ export function getEnvironmentVersions(dependencies) {
       encoding: "utf8"
     });
 
+    logger.log("Yarn dependency check", yarn);
+
     if (!yarn.error && !yarn.stderr) {
       environmentVersions.yarn = formatStdout(yarn.stdout);
     }
@@ -51,6 +54,8 @@ export function getEnvironmentVersions(dependencies) {
       encoding: "utf8"
     });
 
+    logger.log("Git dependency check", git);
+
     if (!git.error && !git.stderr) {
       environmentVersions.git = formatStdout(git.stdout);
     }
@@ -62,6 +67,8 @@ export function getEnvironmentVersions(dependencies) {
       shell: true,
       encoding: "utf8"
     });
+
+    logger.log("Python dependency check", python);
 
     if (python.stdout && !python.error && !python.stderr) {
       const versionMatch = python.stdout.match(PYTHON_VERSION_REGEX);
@@ -79,6 +86,8 @@ export function getEnvironmentVersions(dependencies) {
       encoding: "utf8"
     });
 
+    logger.log("pipenv dependency check", pipenv);
+
     if (!pipenv.stderr && !pipenv.error) {
       environmentVersions.pipenv = formatStdout(pipenv.stdout);
     }
@@ -90,6 +99,8 @@ export function getEnvironmentVersions(dependencies) {
       shell: true,
       encoding: "utf8"
     });
+
+    logger.log("Cookiecutter dependency check", cookiecutter);
 
     if (!cookiecutter.stderr && !cookiecutter.error) {
       environmentVersions.cookiecutter = cookiecutter.stdout;
@@ -110,6 +121,8 @@ export function validateEnvironmentDependencies(
   force = false
 ) {
   section("Checking environment compatibility");
+
+  logger.log("Validating environment dependencies", dependencies);
 
   const configValues = configFile.get(ENVIRONMENT_VERSIONS_CONFIG_NAME);
 

--- a/scripts/utils/environment.js
+++ b/scripts/utils/environment.js
@@ -40,7 +40,7 @@ export function getEnvironmentVersions(dependencies) {
       encoding: "utf8"
     });
 
-    logger.log("Yarn dependency check", yarn);
+    logger.verbose("Yarn dependency check", yarn);
 
     if (!yarn.error && !yarn.stderr) {
       environmentVersions.yarn = formatStdout(yarn.stdout);
@@ -54,7 +54,7 @@ export function getEnvironmentVersions(dependencies) {
       encoding: "utf8"
     });
 
-    logger.log("Git dependency check", git);
+    logger.verbose("Git dependency check", git);
 
     if (!git.error && !git.stderr) {
       environmentVersions.git = formatStdout(git.stdout);
@@ -68,7 +68,7 @@ export function getEnvironmentVersions(dependencies) {
       encoding: "utf8"
     });
 
-    logger.log("Python dependency check", python);
+    logger.verbose("Python dependency check", python);
 
     if (python.stdout && !python.error && !python.stderr) {
       const versionMatch = python.stdout.match(PYTHON_VERSION_REGEX);
@@ -86,7 +86,7 @@ export function getEnvironmentVersions(dependencies) {
       encoding: "utf8"
     });
 
-    logger.log("pipenv dependency check", pipenv);
+    logger.verbose("pipenv dependency check", pipenv);
 
     if (!pipenv.stderr && !pipenv.error) {
       environmentVersions.pipenv = formatStdout(pipenv.stdout);
@@ -100,7 +100,7 @@ export function getEnvironmentVersions(dependencies) {
       encoding: "utf8"
     });
 
-    logger.log("Cookiecutter dependency check", cookiecutter);
+    logger.verbose("Cookiecutter dependency check", cookiecutter);
 
     if (!cookiecutter.stderr && !cookiecutter.error) {
       environmentVersions.cookiecutter = cookiecutter.stdout;
@@ -122,7 +122,7 @@ export function validateEnvironmentDependencies(
 ) {
   section("Checking environment compatibility");
 
-  logger.log("Validating environment dependencies", dependencies);
+  logger.verbose("Validating environment dependencies", dependencies);
 
   const configValues = configFile.get(ENVIRONMENT_VERSIONS_CONFIG_NAME);
 

--- a/scripts/utils/logger.js
+++ b/scripts/utils/logger.js
@@ -2,10 +2,10 @@ class Logger {
   constructor() {
     this._verboseEnabled = process.argv.includes("--verbose");
 
-    this.log("Verbose mode enabled");
+    this.verbose("Verbose mode enabled");
   }
 
-  log(...messages) {
+  verbose(...messages) {
     if (!this._verboseEnabled) {
       return;
     }

--- a/scripts/utils/logger.js
+++ b/scripts/utils/logger.js
@@ -1,0 +1,16 @@
+class Logger {
+  constructor() {
+    this._verboseEnabled = process.argv.includes("--verbose");
+
+    this.log("Verbose mode enabled");
+  }
+
+  log(...messages) {
+    if (!this._verboseEnabled) {
+      return;
+    }
+    console.info("[verbose]", `[${new Date().toISOString()}]`, ...messages);
+  }
+}
+
+export const logger = new Logger();


### PR DESCRIPTION
## Ticket

PLAT-14510
_Related tickets:_
_Related PRs:_

## Type of PR

- [ ] Bugfix
- [ ] New feature
- [X] Minor changes

## Changes introduced

- First pass of verbose changes
- Will add verbose to more commands in second PR

```bash
coho@coho:/mnt/c/work/cli$ node index.js info --verbose
[verbose] [2024-05-01T17:01:07.466Z] Verbose mode enabled

> Checking environment compatibility
[verbose] [2024-05-01T17:01:12.645Z] Validating environment dependencies [ 'yarn', 'git', 'python', 'pipenv', 'cookiecutter' ]
[verbose] [2024-05-01T17:01:12.923Z] Yarn dependency result {
  status: 0,
  signal: null,
  output: [ null, '1.22.10\n', '' ],
  pid: 6926,
  stdout: '1.22.10\n',
  stderr: ''
}
[verbose] [2024-05-01T17:01:12.927Z] Git dependency result {
  status: 0,
  signal: null,
  output: [ null, 'git version 2.34.1\n', '' ],
  pid: 6946,
  stdout: 'git version 2.34.1\n',
  stderr: ''
}
[verbose] [2024-05-01T17:01:12.975Z] Python dependency result {
  status: 0,
  signal: null,
  output: [ null, 'Python 3.8.17\n', '' ],
  pid: 6948,
  stdout: 'Python 3.8.17\n',
  stderr: ''
}
[verbose] [2024-05-01T17:01:13.270Z] pipenv dependency result {
  status: 0,
  signal: null,
  output: [ null, 'pipenv, version 2023.12.1\n', '' ],
  pid: 6997,
  stdout: 'pipenv, version 2023.12.1\n',
  stderr: ''
}
[verbose] [2024-05-01T17:01:13.414Z] Cookiecutter dependency result {
  status: 0,
  signal: null,
  output: [
    null,
    'Cookiecutter 2.6.0 from /home/coho/.local/lib/python3.8/site-packages (Python 3.8.17 (default, Nov 21 2023, 15:41:56) \n' +
      '[GCC 11.4.0])\n',
    ''
  ],
  pid: 7002,
  stdout: 'Cookiecutter 2.6.0 from /home/coho/.local/lib/python3.8/site-packages (Python 3.8.17 (default, Nov 21 2023, 15:41:56) \n' +
    '[GCC 11.4.0])\n',
  stderr: ''
}

```
