### PR TITLE
ReOpened: comparing and printing local and registry version of CB CLI

### DIFF
--- a/scripts/utils/environment.js
+++ b/scripts/utils/environment.js
@@ -140,7 +140,7 @@ export function getEnvironmentVersions(dependencies) {
       environmentVersions.cli = {
         ...environmentVersions.cli,
         local: {
-          version: localCLI[1] || "Not installed"
+          version: localCLI?.[1] || "0.0.0"
         }
       };
     }


### PR DESCRIPTION
## Ticket

ASBLY-26
_Related tickets:_
_Related PRs:_

## Type of PR

- [ ] Bugfix
- [x] New feature
- [ ] Minor changes

## Changes introduced

while running any CB CLI command it prints out currently installed and latest version from registry of the CLI
It also warns the user that they have older version and provide a command to update the version

## Test and review

Run any/all commads and it should print something like this
CLI Version current: 3.1.0 latest: 3.1.0
or
⚠ CLI Version current: 3.0.0 latest: 3.1.0 ⚠ You have an older version. Please update to new version by following this command: npm install -g crowdbotics

depending of your state of environment